### PR TITLE
add run link to all failed expectations

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -22,6 +22,7 @@ const { log } = Apify.utils;
  *  name?: string,
  *  options?: Parameters<Apify.callTask>[2]
  *  nonce?: string
+ *  prefilledInput?: boolean
  * }} RunParams
  */
 
@@ -39,7 +40,7 @@ const isRunResult = (run) => (
  */
 const formatRunMessage = (runResult) => (message) => {
     const namePart = runResult.data.name ? `${runResult.data.name}\n` : '';
-    const taskOrActorPart = runResult.data.taskName ? `${runResult.data.taskName} - ${runResult.data.actorName}` : runResult.data.actorName
+    const taskOrActorPart = runResult.data.taskName ? `${runResult.data.taskName} - ${runResult.data.actorName}` : runResult.data.actorName;
     const runLink = createRunLink({
         actorId: runResult.data.actId,
         taskId: runResult.data.taskId,


### PR DESCRIPTION
closes #5 ; note that this is based on top of #6 to review as a separate commit

The issue here was that we define a custom formatter for our newly defined failed expectations (`expectAsync(runResult).toHaveStatus()`), but e.g. for the log, it's just a plain jasmine expect on a string. I solve it by adding the runLink to the context of the running spec, and then extending the reporter to print it for the failed specs.

Plus there's a few drive-by code improvements

example outputs:

```
**************************************************
*                    Failures                    *
**************************************************

1) testing-test-name tests
  - actor-testing-example-task - zillow-detail-scraper:0.0.46
  https://my.apify.com/actors/tasks/hir05AxQmb9VjAaNW/runs/Z6R8vcsayR0Sav6kA : Expected status to be "CEEDED", got "SUCCEEDED"

  - Expected '2024-09-17T10:54:06.464Z ACTOR: Pulling Docker image of build s8Xdvl4DlwJD4acJk from repository.
  2024-09-17T10:54:08.377Z ACTOR: Creating Docker container.
  2024-09-17T10:54:09.065Z ACTOR: Starting Docker container.
  2024-09-17T10:54:10.618Z INFO  System info {"apifyVersion":"3.1.15","apifyClientVersion":"2.8.4","crawleeVersion":"3.7.2","osType":"Linux","nodeVersion":"v20.17.0"}
  2024-09-17T10:54:12.168Z INFO  HttpCrawler: Starting the crawler.
  2024-09-17T10:54:16.212Z INFO  HttpCrawler: All requests from the queue have been processed, the crawler will shut down.
  2024-09-17T10:54:16.385Z INFO  HttpCrawler: Final request statistics: {"requestsFinished":1,"requestsFailed":0,"retryHistogram":[1],"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":3922,"requestsFinishedPerMinute":14,"requestsFailedPerMinute":0,"requestTotalDurationMillis":3922,"requestsTotal":1,"crawlerRuntimeMillis":4332}
  2024-09-17T10:54:16.389Z INFO  HttpCrawler: Finished! Total 1 requests: 1 succ ... not to contain 'Finished'.
      at test.js:5:29
  Related runs: https://my.apify.com/actors/tasks/hir05AxQmb9VjAaNW/runs/Z6R8vcsayR0Sav6kA

Executed 1 of 1 spec (1 FAILED) in 2 secs.
ERROR 
  Error: Failed tests but not retrying.
```

^^ this is two failed `expect()`s in one test spec, the first expect uses output formatter defined in the actor-testing code, the second fail is from a jasmine-native assertion (`string.not.toContain()`), which doesn't produce any format.

```
**************************************************
*                    Failures                    *
**************************************************

1) testing-test-name tests
  - actor-testing-example-task - zillow-detail-scraper:0.0.46
  https://my.apify.com/actors/tasks/hir05AxQmb9VjAaNW/runs/Z6R8vcsayR0Sav6kA : Expected status to be "CEEDED", got "SUCCEEDED"

  Related runs: https://my.apify.com/actors/tasks/hir05AxQmb9VjAaNW/runs/Z6R8vcsayR0Sav6kA

Executed 1 of 1 spec (1 FAILED) in 2 secs.
```

^^ here's just the custom expect failed

---

Advantage is that the extended reporter only links the run once per spec, even when there are multiple failed expectations. But the issue here is that we're duplicating the run link for now in some cases, because also the `expect`s themselves show it. I'm inclined to remove it from the formatter used for the error messages (or maybe even ditch the formatter completely), but I wasn't sure whether it's 100% safe, so for now we have it just like this.