### PR TITLE
chore: bump `apify-client` and `apify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "2.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "apify": "^2.2.1",
-                "apify-client": "^2.9",
+                "apify": "^2.3.2",
+                "apify-client": "^2.12.0",
                 "arktype": "2.0.0-dev.26",
                 "escape-string-regexp": "^4.0.0",
                 "jasmine": "3.10.0",
@@ -524,9 +524,9 @@
             }
         },
         "node_modules/apify-client": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.9.3.tgz",
-            "integrity": "sha512-qQn1BxNL29cxwFSpgA3oc53i88xdYGtNZfYDFCoi3MJyds1XKx2NDPuf65YwQS/n0Qsfq1uHJqbkqV5oo/FSXw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.12.0.tgz",
+            "integrity": "sha512-h04rPVft8tNjnwZswqF2k46bdHZWsDsfOE8PkmklZ9+/s/mb/Q/dMOXCx0u2+RTc8QoAkYS9LYs97wZyUWpoag==",
             "dependencies": {
                 "@apify/consts": "^2.25.0",
                 "@apify/log": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -4,21 +4,21 @@
     "private": true,
     "description": "This is a boilerplate of an Apify actor.",
     "dependencies": {
-        "apify": "^2.2.1",
-        "apify-client": "^2.9",
+        "apify": "^2.3.2",
+        "apify-client": "^2.12.0",
         "arktype": "2.0.0-dev.26",
-        "moment": "^2.29.1",
-        "lodash": "^4.17.21",
+        "escape-string-regexp": "^4.0.0",
         "jasmine": "3.10.0",
         "jasmine-expect": "^5.0.0",
         "jasmine-spec-reporter": "^7.0.0",
-        "xxhash-addon": "^1.4.0",
-        "escape-string-regexp": "^4.0.0"
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "xxhash-addon": "^1.4.0"
     },
     "devDependencies": {
+        "@apify/eslint-config": "^0.1.4",
         "@types/jasmine": "^3.10.2",
         "@types/lodash": "^4.14.176",
-        "@apify/eslint-config": "^0.1.4",
         "eslint": "^7.32.0"
     },
     "scripts": {


### PR DESCRIPTION
Will enable using `maxTotalChargeUsd` when starting runs. Needed for PPE tests