### PR TITLE
feat(matchers): add pass on format parameter in `withDataset`

### DIFF
--- a/src/matchers.js
+++ b/src/matchers.js
@@ -327,7 +327,7 @@ const withDataset = async ({ result, value, args, client, format }) => {
 
     return callbackValue({
         value,
-        args: { dataset, info },
+        args: { dataset, info, format },
         format,
     });
 };


### PR DESCRIPTION
This change allows us to access `format` directly from the `withDataset` handler, such we can log which fields we found issues with inside the matcher callback.

In the instagram-post test we use `runResult.format` inside an `expectAsync().withDataset`. As the point of `expectAsync` is that it awaits a promise for you, and catches promise rejections as failures, us awaiting the promise of the run outside is ..weird.