### PR TITLE
fix: do not stop on failed expectation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -308,7 +308,7 @@ Apify.main(async () => {
     instance.addHelperFile('jasmine-expect');
     instance.randomizeTests(false);
     instance.stopOnSpecFailure(false);
-    instance.stopSpecOnExpectationFailure(true);
+    instance.stopSpecOnExpectationFailure(false);
     instance.exitOnCompletion = false;
 
     const filteredTests = [...new Set((filter || []).map((s) => s.trim()).filter(Boolean))]


### PR DESCRIPTION
I'm not really sure what the ratio was in this [commit](https://github.com/apify-projects/store-actor-testing/commit/2b92f55d1e031ab400b9afbc678be73fa0eff872) but is it possible to revert it? 

The slack message is not affected since the array of failed messages is sliced to the first element (line `213`).